### PR TITLE
chore(test): Add Kamelet's custom from test cases

### DIFF
--- a/packages/ui/src/models/kamelets-catalog.ts
+++ b/packages/ui/src/models/kamelets-catalog.ts
@@ -2,6 +2,19 @@ import { FromDefinition, Kamelet, ObjectMeta, RouteTemplateBeanDefinition } from
 import { SourceSchemaType } from './camel/source-schema-type';
 import { KaotoSchemaDefinition } from './kaoto-schema';
 
+export const enum KameletKnownAnnotations {
+  Icon = 'camel.apache.org/kamelet.icon',
+  SupportLevel = 'camel.apache.org/kamelet.support.level',
+  CatalogVersion = 'camel.apache.org/catalog.version',
+  Provider = 'camel.apache.org/provider',
+  Group = 'camel.apache.org/kamelet.group',
+  Namespace = 'camel.apache.org/kamelet.namespace',
+}
+
+export const enum KameletKnownLabels {
+  Type = 'camel.apache.org/kamelet.type',
+}
+
 export interface IKameletDefinition extends Omit<Kamelet, 'kind' | 'metadata' | 'spec'> {
   kind: SourceSchemaType.Kamelet;
   metadata: IKameletMetadata;
@@ -16,17 +29,17 @@ export interface IKameletMetadata extends ObjectMeta {
 }
 
 export interface IKameletMetadataAnnotations {
-  'camel.apache.org/kamelet.support.level': string;
-  'camel.apache.org/catalog.version': string;
-  'camel.apache.org/kamelet.icon': string;
-  'camel.apache.org/provider': string;
-  'camel.apache.org/kamelet.group': string;
-  'camel.apache.org/kamelet.namespace': string;
+  [KameletKnownAnnotations.SupportLevel]: string;
+  [KameletKnownAnnotations.CatalogVersion]: string;
+  [KameletKnownAnnotations.Icon]: string;
+  [KameletKnownAnnotations.Provider]: string;
+  [KameletKnownAnnotations.Group]: string;
+  [KameletKnownAnnotations.Namespace]: string;
   [k: string]: string;
 }
 
 export interface IKameletMetadataLabels {
-  'camel.apache.org/kamelet.type': string;
+  [KameletKnownLabels.Type]: string;
   [k: string]: string;
 }
 
@@ -36,6 +49,14 @@ export interface IKameletSpec {
   template: {
     beans?: RouteTemplateBeanDefinition[];
     from: FromDefinition;
+  };
+  types?: {
+    in?: {
+      mediaType: string;
+    };
+    out?: {
+      mediaType: string;
+    };
   };
 }
 
@@ -56,4 +77,19 @@ export interface IKameletSpecProperty {
   type: string;
   default?: string | boolean | number;
   example?: string;
+}
+
+export interface IKameletCustomDefinition {
+  name: string;
+  title: string;
+  description: string;
+  type: string;
+  icon: string;
+  supportLevel: string;
+  catalogVersion: string;
+  provider: string;
+  group: string;
+  namespace: string;
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
 }

--- a/packages/ui/src/utils/get-actual-kamelet-schema-from-custom-schema.test.ts
+++ b/packages/ui/src/utils/get-actual-kamelet-schema-from-custom-schema.test.ts
@@ -1,11 +1,15 @@
-import { getActualKameletSchemaFromCustomSchema } from './get-actual-kamelet-schema-from-custom-schema';
+import cloneDeep from 'lodash.clonedeep';
+import { SourceSchemaType } from '../models/camel/source-schema-type';
 import { IKameletDefinition } from '../models/kamelets-catalog';
+import { getActualKameletSchemaFromCustomSchema } from './get-actual-kamelet-schema-from-custom-schema';
 
 describe('getActualKameletSchemaFromCustomSchema', () => {
-  it('should update the kamelet schema according to the custom schema', () => {
-    const inputKameletStruct = {
+  let inputKameletStruct: IKameletDefinition;
+
+  beforeEach(() => {
+    inputKameletStruct = {
       apiVersion: 'camel.apache.org/v1',
-      kind: 'Kamelet',
+      kind: SourceSchemaType.Kamelet,
       metadata: {
         annotations: {
           'camel.apache.org/catalog.version': 'main-SNAPSHOT',
@@ -14,6 +18,7 @@ describe('getActualKameletSchemaFromCustomSchema', () => {
             'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTkuMC4wLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjAgNjAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYwIDYwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGQ9Ik00OC4wMTQsNDIuODg5bC05LjU1My00Ljc3NkMzNy41NiwzNy42NjIsMzcsMzYuNzU2LDM3LDM1Ljc0OHYtMy4zODFjMC4yMjktMC4yOCwwLjQ3LTAuNTk5LDAuNzE5LTAuOTUxCgljMS4yMzktMS43NSwyLjIzMi0zLjY5OCwyLjk1NC01Ljc5OUM0Mi4wODQsMjQuOTcsNDMsMjMuNTc1LDQzLDIydi00YzAtMC45NjMtMC4zNi0xLjg5Ni0xLTIuNjI1di01LjMxOQoJYzAuMDU2LTAuNTUsMC4yNzYtMy44MjQtMi4wOTItNi41MjVDMzcuODU0LDEuMTg4LDM0LjUyMSwwLDMwLDBzLTcuODU0LDEuMTg4LTkuOTA4LDMuNTNDMTcuNzI0LDYuMjMxLDE3Ljk0NCw5LjUwNiwxOCwxMC4wNTYKCXY1LjMxOWMtMC42NCwwLjcyOS0xLDEuNjYyLTEsMi42MjV2NGMwLDEuMjE3LDAuNTUzLDIuMzUyLDEuNDk3LDMuMTA5YzAuOTE2LDMuNjI3LDIuODMzLDYuMzYsMy41MDMsNy4yMzd2My4zMDkKCWMwLDAuOTY4LTAuNTI4LDEuODU2LTEuMzc3LDIuMzJsLTguOTIxLDQuODY2QzguODAxLDQ0LjQyNCw3LDQ3LjQ1OCw3LDUwLjc2MlY1NGMwLDQuNzQ2LDE1LjA0NSw2LDIzLDZzMjMtMS4yNTQsMjMtNnYtMy4wNDMKCUM1Myw0Ny41MTksNTEuMDg5LDQ0LjQyNyw0OC4wMTQsNDIuODg5eiIvPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8Zz4KPC9nPgo8L3N2Zz4K',
           'camel.apache.org/kamelet.support.level': 'Stable',
           'camel.apache.org/provider': 'Apache Software Foundation',
+          'camel.apache.org/kamelet.namespace': 'default',
         },
         labels: {
           'camel.apache.org/kamelet.type': 'Source',
@@ -60,7 +65,17 @@ describe('getActualKameletSchemaFromCustomSchema', () => {
         },
       },
     };
+  });
 
+  it(`should preserve kamelet's original values when loading a malformed custom schema`, () => {
+    const originalValue = cloneDeep(inputKameletStruct);
+    const value = undefined;
+
+    getActualKameletSchemaFromCustomSchema(inputKameletStruct, value as unknown as Record<string, unknown>);
+    expect(inputKameletStruct).toEqual(originalValue);
+  });
+
+  it('should get the kamelet schema from the custom schema', () => {
     const value = {
       name: 'test',
       title: 'kamelet-35256',
@@ -80,9 +95,9 @@ describe('getActualKameletSchemaFromCustomSchema', () => {
       },
     };
 
-    const outputKameletStruct = {
+    const outputKameletStruct: IKameletDefinition = {
       apiVersion: 'camel.apache.org/v1',
-      kind: 'Kamelet',
+      kind: SourceSchemaType.Kamelet,
       metadata: {
         annotations: {
           'camel.apache.org/catalog.version': 'main-SNAPSHOT',

--- a/packages/ui/src/utils/get-actual-kamelet-schema-from-custom-schema.ts
+++ b/packages/ui/src/utils/get-actual-kamelet-schema-from-custom-schema.ts
@@ -1,23 +1,60 @@
+import {
+  IKameletDefinition,
+  IKameletMetadataAnnotations,
+  IKameletMetadataLabels,
+  KameletKnownAnnotations,
+  KameletKnownLabels,
+} from '../models/kamelets-catalog';
+import { getValue } from './get-value';
 import { setValue } from './set-value';
-import { IKameletDefinition } from '../models/kamelets-catalog';
 
 export const getActualKameletSchemaFromCustomSchema = (
   kamelet: IKameletDefinition,
   value: Record<string, unknown>,
 ): void => {
-  kamelet.metadata.name = value.name as string;
-  kamelet.spec.definition.title = value.title as string;
-  kamelet.spec.definition.description = value.description as string;
+  const previousName = getValue(kamelet, 'metadata.name');
+  const previousTitle = getValue(kamelet, 'spec.definition.title');
+  const previousDescription = getValue(kamelet, 'spec.definition.description');
+
+  const newName: string = getValue(value, 'name');
+  const newTitle: string = getValue(value, 'title');
+  const newDescription: string = getValue(value, 'description');
+
+  setValue(kamelet, 'metadata.name', newName ?? previousName);
+  setValue(kamelet, 'spec.definition.title', newTitle ?? previousTitle);
+  setValue(kamelet, 'spec.definition.description', newDescription ?? previousDescription);
+
+  const previousAnnotations = getValue(kamelet, 'metadata.annotations', {} as IKameletMetadataAnnotations);
+  const previousIcon = previousAnnotations[KameletKnownAnnotations.Icon];
+  const previousSupportLevel = previousAnnotations[KameletKnownAnnotations.SupportLevel];
+  const previousCatalogVersion = previousAnnotations[KameletKnownAnnotations.CatalogVersion];
+  const previousProvider = previousAnnotations[KameletKnownAnnotations.Provider];
+  const previousGroup = previousAnnotations[KameletKnownAnnotations.Group];
+  const previousNamespace = previousAnnotations[KameletKnownAnnotations.Namespace];
+
+  const newIcon = getValue(value, 'icon');
+  const newSupportLevel = getValue(value, 'supportLevel');
+  const newCatalogVersion = getValue(value, 'catalogVersion');
+  const newProvider = getValue(value, 'provider');
+  const newGroup = getValue(value, 'group');
+  const newNamespace = getValue(value, 'namespace');
 
   const customAnnotations = {
-    'camel.apache.org/kamelet.icon': value.icon,
-    'camel.apache.org/kamelet.support.level': value.supportLevel,
-    'camel.apache.org/catalog.version': value.catalogVersion,
-    'camel.apache.org/provider': value.provider,
-    'camel.apache.org/kamelet.group': value.group,
-    'camel.apache.org/kamelet.namespace': value.namespace,
+    [KameletKnownAnnotations.Icon]: newIcon ?? previousIcon,
+    [KameletKnownAnnotations.SupportLevel]: newSupportLevel ?? previousSupportLevel,
+    [KameletKnownAnnotations.CatalogVersion]: newCatalogVersion ?? previousCatalogVersion,
+    [KameletKnownAnnotations.Provider]: newProvider ?? previousProvider,
+    [KameletKnownAnnotations.Group]: newGroup ?? previousGroup,
+    [KameletKnownAnnotations.Namespace]: newNamespace ?? previousNamespace,
   };
 
-  setValue(kamelet.metadata, 'labels', { ...(value.labels as object), 'camel.apache.org/kamelet.type': value.type });
-  setValue(kamelet.metadata, 'annotations', { ...(value.annotations as object), ...customAnnotations });
+  const previousType = getValue(kamelet, 'metadata.labels', {} as IKameletMetadataLabels)[KameletKnownLabels.Type];
+  const newLabels = getValue(value, 'labels', {});
+  Object.assign(newLabels, {
+    [KameletKnownLabels.Type]: getValue(value, 'type', previousType),
+  });
+  const newAnnotations = Object.assign(getValue(value, 'annotations', {}), customAnnotations);
+
+  setValue(kamelet, 'metadata.labels', newLabels);
+  setValue(kamelet, 'metadata.annotations', newAnnotations);
 };

--- a/packages/ui/src/utils/get-custom-schema-from-actual-kamelet-schema.test.ts
+++ b/packages/ui/src/utils/get-custom-schema-from-actual-kamelet-schema.test.ts
@@ -1,11 +1,14 @@
-import { getCustomSchemaFromActualKameletSchema } from './get-custom-schema-from-actual-kamelet-schema';
+import { SourceSchemaType } from '../models/camel/source-schema-type';
 import { IKameletDefinition } from '../models/kamelets-catalog';
+import { getCustomSchemaFromActualKameletSchema } from './get-custom-schema-from-actual-kamelet-schema';
 
 describe('getCustomSchemaFromActualKameletSchema', () => {
-  it('should set the value at the given path', () => {
-    const inputKameletStruct = {
+  let inputKameletStruct: IKameletDefinition;
+
+  beforeEach(() => {
+    inputKameletStruct = {
       apiVersion: 'camel.apache.org/v1',
-      kind: 'Kamelet',
+      kind: SourceSchemaType.Kamelet,
       metadata: {
         annotations: {
           'camel.apache.org/catalog.version': 'main-SNAPSHOT',
@@ -63,7 +66,29 @@ describe('getCustomSchemaFromActualKameletSchema', () => {
         },
       },
     };
+  });
 
+  it('should get a custom kamelet definition from a empty kamelet', () => {
+    const expectedCustomSchema = {
+      name: '',
+      title: '',
+      description: '',
+      type: undefined,
+      icon: undefined,
+      supportLevel: undefined,
+      catalogVersion: undefined,
+      provider: undefined,
+      group: undefined,
+      namespace: undefined,
+      labels: {},
+      annotations: {},
+    };
+
+    const customSchema = getCustomSchemaFromActualKameletSchema({} as IKameletDefinition);
+    expect(customSchema).toEqual(expectedCustomSchema);
+  });
+
+  it('should get a custom kamelet definition from a kamelet official spec', () => {
     const expectedCustomSchema = {
       name: 'test',
       title: 'kamelet-35256',

--- a/packages/ui/src/utils/get-custom-schema-from-actual-kamelet-schema.ts
+++ b/packages/ui/src/utils/get-custom-schema-from-actual-kamelet-schema.ts
@@ -1,50 +1,58 @@
-import { setValue } from './set-value';
-import { IKameletDefinition } from '../models/kamelets-catalog';
+import {
+  IKameletCustomDefinition,
+  IKameletDefinition,
+  IKameletMetadataAnnotations,
+  IKameletMetadataLabels,
+  KameletKnownAnnotations,
+  KameletKnownLabels,
+} from '../models/kamelets-catalog';
+import { getValue } from './get-value';
 
-export const getCustomSchemaFromActualKameletSchema = (kamelet: IKameletDefinition): Record<string, unknown> => {
-  const customSchema = {
-    name: kamelet.metadata.name,
-    title: kamelet.spec.definition.title,
-    description: kamelet.spec.definition.description,
-    type: kamelet.metadata.labels['camel.apache.org/kamelet.type'],
-    icon: kamelet.metadata.annotations['camel.apache.org/kamelet.icon'],
-    supportLevel: kamelet.metadata.annotations['camel.apache.org/kamelet.support.level'],
-    catalogVersion: kamelet.metadata.annotations['camel.apache.org/catalog.version'],
-    provider: kamelet.metadata.annotations['camel.apache.org/provider'],
-    group: kamelet.metadata.annotations['camel.apache.org/kamelet.group'],
-    namespace: kamelet.metadata.annotations['camel.apache.org/kamelet.namespace'],
+export const getCustomSchemaFromActualKameletSchema = (kamelet: IKameletDefinition): IKameletCustomDefinition => {
+  const name = getValue(kamelet, 'metadata.name', '');
+  const title = getValue(kamelet, 'spec.definition.title', '');
+  const description = getValue(kamelet, 'spec.definition.description', '');
+  const type = getValue(kamelet, 'metadata.labels', {} as IKameletMetadataLabels)[KameletKnownLabels.Type];
+  const annotations = getValue(kamelet, 'metadata.annotations', {} as IKameletMetadataAnnotations);
+  const labels = getValue(kamelet, 'metadata.labels', {} as IKameletMetadataLabels);
+
+  const filteredLabels = Object.keys(labels).reduce((acc, key) => {
+    if (key !== KameletKnownLabels.Type) {
+      acc[key] = labels[key];
+    }
+    return acc;
+  }, {} as IKameletMetadataLabels);
+
+  const filteredAnnotations = Object.entries(annotations).reduce((acc, [annotationKey, annotationValue]) => {
+    switch (annotationKey) {
+      case KameletKnownAnnotations.Icon:
+      case KameletKnownAnnotations.SupportLevel:
+      case KameletKnownAnnotations.CatalogVersion:
+      case KameletKnownAnnotations.Provider:
+      case KameletKnownAnnotations.Group:
+      case KameletKnownAnnotations.Namespace:
+        break;
+      default:
+        acc[annotationKey] = annotationValue as string;
+    }
+
+    return acc;
+  }, {} as IKameletMetadataAnnotations);
+
+  const customSchema: IKameletCustomDefinition = {
+    name,
+    title,
+    description,
+    type,
+    icon: annotations[KameletKnownAnnotations.Icon],
+    supportLevel: annotations[KameletKnownAnnotations.SupportLevel],
+    catalogVersion: annotations[KameletKnownAnnotations.CatalogVersion],
+    provider: annotations[KameletKnownAnnotations.Provider],
+    group: annotations[KameletKnownAnnotations.Group],
+    namespace: annotations[KameletKnownAnnotations.Namespace],
+    labels: filteredLabels,
+    annotations: filteredAnnotations,
   };
-
-  const labels: { [key: string]: string } = {};
-  if (kamelet.metadata.labels && Object.keys(kamelet.metadata.labels).length > 0) {
-    for (const [labelKey, labelValue] of Object.entries(kamelet.metadata.labels)) {
-      switch (labelKey) {
-        case 'camel.apache.org/kamelet.type':
-          break;
-        default:
-          labels[labelKey] = labelValue as string;
-      }
-    }
-  }
-  setValue(customSchema, 'labels', labels);
-
-  const annotations: { [key: string]: string } = {};
-  if (kamelet.metadata.annotations && Object.keys(kamelet.metadata.annotations).length > 0) {
-    for (const [annotationKey, annotationValue] of Object.entries(kamelet.metadata.annotations)) {
-      switch (annotationKey) {
-        case 'camel.apache.org/kamelet.icon':
-        case 'camel.apache.org/kamelet.support.level':
-        case 'camel.apache.org/catalog.version':
-        case 'camel.apache.org/provider':
-        case 'camel.apache.org/kamelet.group':
-        case 'camel.apache.org/kamelet.namespace':
-          break;
-        default:
-          annotations[annotationKey] = annotationValue as string;
-      }
-    }
-  }
-  setValue(customSchema, 'annotations', annotations);
 
   return customSchema;
 };


### PR DESCRIPTION
### Context
This PR adds a couple of missing test cases for when the source definitions are `empty` or `undefined`. It also adds a bit of type safety.