### PR TITLE
fix(canvas): Update flow id on CanvasForm close

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasForm.test.tsx
@@ -8,43 +8,61 @@ import {
   CamelCatalogService,
   CamelRouteVisualEntity,
   CatalogKind,
+  ICamelComponentDefinition,
   ICamelDataformatDefinition,
   ICamelLanguageDefinition,
   ICamelLoadBalancerDefinition,
   ICamelProcessorDefinition,
+  IKameletDefinition,
   KaotoSchemaDefinition,
 } from '../../../models';
 import { IVisualizationNode, VisualComponentSchema } from '../../../models/visualization/base-visual-entity';
-import { EntitiesContext } from '../../../providers/entities.provider';
+import { VisibleFlowsContext, VisibleFlowsProvider } from '../../../providers';
+import { EntitiesContext, EntitiesProvider } from '../../../providers/entities.provider';
+import { camelRouteJson } from '../../../stubs';
 import { SchemaService } from '../../Form';
 import { CustomAutoFieldDetector } from '../../Form/CustomAutoField';
 import { CanvasForm } from './CanvasForm';
 import { CanvasNode } from './canvas.models';
+import { CanvasService } from './canvas.service';
+import { VisualFlowsApi } from '../../../models/visualization/flows/support/flows-visibility';
 
 describe('CanvasForm', () => {
+  let camelRouteVisualEntity: CamelRouteVisualEntity;
+  let selectedNode: CanvasNode;
+  let componentCatalogMap: Record<string, ICamelComponentDefinition>;
+  let patternCatalogMap: Record<string, ICamelProcessorDefinition>;
+  let kameletCatalogMap: Record<string, IKameletDefinition>;
   const schemaService = new SchemaService();
 
-  const schema = {
-    type: 'object',
-    properties: {
-      name: {
-        type: 'string',
-      },
-    },
-  } as unknown as KaotoSchemaDefinition['schema'];
-
   beforeAll(async () => {
-    const patternCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file);
-    delete patternCatalog.default;
+    componentCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file);
+    delete componentCatalogMap.default;
+    const modelCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.models.file);
+    delete modelCatalog.default;
+    patternCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file);
+    delete patternCatalogMap.default;
+    kameletCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
+    delete kameletCatalogMap.default;
     const languageCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.languages.file);
     delete languageCatalog.default;
     const dataformatCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.dataformats.file);
     delete dataformatCatalog.default;
     const loadbalancerCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.loadbalancers.file);
     delete loadbalancerCatalog.default;
+    const entitiesCatalog = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.entities.file);
+    delete entitiesCatalog.default;
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Component,
+      componentCatalogMap as unknown as Record<string, ICamelComponentDefinition>,
+    );
     CamelCatalogService.setCatalogKey(
       CatalogKind.Pattern,
-      patternCatalog as unknown as Record<string, ICamelProcessorDefinition>,
+      patternCatalogMap as unknown as Record<string, ICamelProcessorDefinition>,
+    );
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Kamelet,
+      kameletCatalogMap as unknown as Record<string, IKameletDefinition>,
     );
     CamelCatalogService.setCatalogKey(
       CatalogKind.Language,
@@ -58,31 +76,29 @@ describe('CanvasForm', () => {
       CatalogKind.Loadbalancer,
       loadbalancerCatalog as unknown as Record<string, ICamelLoadBalancerDefinition>,
     );
+    CamelCatalogService.setCatalogKey(
+      CatalogKind.Entity,
+      entitiesCatalog as unknown as Record<string, ICamelProcessorDefinition>,
+    );
+  });
+
+  beforeEach(() => {
+    camelRouteVisualEntity = new CamelRouteVisualEntity(camelRouteJson.route);
+    const { nodes } = CanvasService.getFlowDiagram(camelRouteVisualEntity.toVizNode());
+    selectedNode = nodes[2]; // choice
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should render', () => {
-    const visualComponentSchema: VisualComponentSchema = {
-      title: 'My Node',
-      schema,
-      definition: {
-        name: 'my node',
-      },
-    };
-
-    const selectedNode: CanvasNode = {
-      id: '1',
-      type: 'node',
-      data: {
-        vizNode: {
-          getComponentSchema: () => visualComponentSchema,
-        } as IVisualizationNode,
-      },
-    };
-
     const { container } = render(
-      <EntitiesContext.Provider value={null}>
-        <CanvasForm selectedNode={selectedNode} />
-      </EntitiesContext.Provider>,
+      <EntitiesProvider>
+        <VisibleFlowsProvider>
+          <CanvasForm selectedNode={selectedNode} />
+        </VisibleFlowsProvider>
+      </EntitiesProvider>,
     );
 
     expect(container).toMatchSnapshot();
@@ -95,13 +111,16 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => undefined,
-        } as IVisualizationNode,
+          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+        } as unknown as IVisualizationNode,
       },
     };
 
     const { container } = render(
       <EntitiesContext.Provider value={null}>
-        <CanvasForm selectedNode={selectedNode} />
+        <VisibleFlowsProvider>
+          <CanvasForm selectedNode={selectedNode} />
+        </VisibleFlowsProvider>
       </EntitiesContext.Provider>,
     );
 
@@ -121,13 +140,16 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => visualComponentSchema,
-        } as IVisualizationNode,
+          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+        } as unknown as IVisualizationNode,
       },
     };
 
     const { container } = render(
       <EntitiesContext.Provider value={null}>
-        <CanvasForm selectedNode={selectedNode} />
+        <VisibleFlowsProvider>
+          <CanvasForm selectedNode={selectedNode} />
+        </VisibleFlowsProvider>
       </EntitiesContext.Provider>,
     );
 
@@ -149,20 +171,49 @@ describe('CanvasForm', () => {
       data: {
         vizNode: {
           getComponentSchema: () => visualComponentSchema,
-        } as IVisualizationNode,
+          getBaseEntity: () => new CamelRouteVisualEntity(camelRouteJson.route),
+        } as unknown as IVisualizationNode,
       },
     };
 
     render(
       <EntitiesContext.Provider value={null}>
-        <CanvasForm selectedNode={selectedNode} />
+        <VisibleFlowsProvider>
+          <CanvasForm selectedNode={selectedNode} />
+        </VisibleFlowsProvider>
       </EntitiesContext.Provider>,
     );
 
     expect(visualComponentSchema.definition.parameters).toEqual({});
   });
 
+  it('should allow consumers to update the entity ID', async () => {
+    const originalFlowId = camelRouteVisualEntity.id;
+    const newId = 'MyNewId';
+    const dispatchSpy = jest.fn();
+    const visualFlowsApi = new VisualFlowsApi(dispatchSpy);
+    const { nodes } = CanvasService.getFlowDiagram(camelRouteVisualEntity.toVizNode());
+    selectedNode = nodes[nodes.length - 1]; // route group node
+
+    const wrapper = render(
+      <EntitiesProvider>
+        <VisibleFlowsContext.Provider value={{ visibleFlows: { [originalFlowId]: true }, visualFlowsApi }}>
+          <CanvasForm selectedNode={selectedNode} />
+        </VisibleFlowsContext.Provider>
+      </EntitiesProvider>,
+    );
+
+    const idField = await wrapper.findByLabelText('Id');
+
+    expect(camelRouteVisualEntity.id).toEqual(newId);
+    expect(dispatchSpy).toHaveBeenCalledWith({ type: 'renameFlow', originalFlowId, newId });
+  });
+
   describe('should persists changes from both expression editor and main form', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
     it('expression => main form', async () => {
       const camelRoute = {
         from: {
@@ -189,7 +240,9 @@ describe('CanvasForm', () => {
 
       render(
         <EntitiesContext.Provider value={null}>
-          <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          <VisibleFlowsProvider>
+            <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          </VisibleFlowsProvider>
         </EntitiesContext.Provider>,
       );
       const launchExpression = screen.getByTestId('launch-expression-modal-btn');
@@ -253,7 +306,9 @@ describe('CanvasForm', () => {
 
       render(
         <EntitiesContext.Provider value={null}>
-          <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          <VisibleFlowsProvider>
+            <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          </VisibleFlowsProvider>
         </EntitiesContext.Provider>,
       );
       const filtered = screen.getAllByRole('textbox').filter((textbox) => textbox.getAttribute('label') === 'Name');
@@ -292,6 +347,10 @@ describe('CanvasForm', () => {
   });
 
   describe('should persists changes from both dataformat editor and main form', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
     it('dataformat => main form', async () => {
       const camelRoute = {
         from: {
@@ -318,7 +377,9 @@ describe('CanvasForm', () => {
 
       render(
         <EntitiesContext.Provider value={null}>
-          <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          <VisibleFlowsProvider>
+            <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          </VisibleFlowsProvider>
         </EntitiesContext.Provider>,
       );
       const button = screen
@@ -368,7 +429,9 @@ describe('CanvasForm', () => {
 
       render(
         <EntitiesContext.Provider value={null}>
-          <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          <VisibleFlowsProvider>
+            <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          </VisibleFlowsProvider>
         </EntitiesContext.Provider>,
       );
       const idInput = screen.getAllByRole('textbox').filter((textbox) => textbox.getAttribute('label') === 'Id');
@@ -394,6 +457,10 @@ describe('CanvasForm', () => {
   });
 
   describe('should persists changes from both loadbalancer editor and main form', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
     it('loadbalancer => main form', async () => {
       const camelRoute = {
         from: {
@@ -420,7 +487,9 @@ describe('CanvasForm', () => {
 
       render(
         <EntitiesContext.Provider value={null}>
-          <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          <VisibleFlowsProvider>
+            <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          </VisibleFlowsProvider>
         </EntitiesContext.Provider>,
       );
       const button = screen
@@ -470,7 +539,9 @@ describe('CanvasForm', () => {
 
       render(
         <EntitiesContext.Provider value={null}>
-          <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          <VisibleFlowsProvider>
+            <CanvasForm selectedNode={selectedNode as unknown as CanvasNode} />
+          </VisibleFlowsProvider>
         </EntitiesContext.Provider>,
       );
       const idInput = screen.getAllByRole('textbox').filter((textbox) => textbox.getAttribute('label') === 'Id');
@@ -495,76 +566,73 @@ describe('CanvasForm', () => {
     });
   });
 
-  /*
-   * Exhaustive tests
-   */
-
-  it('should render for all component without an error', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const componentCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.components.file);
-    Object.entries(componentCatalogMap).forEach(([name, catalog]) => {
-      try {
-        if (name === 'default') return;
-        /* eslint-disable  @typescript-eslint/no-explicit-any */
-        const schema = schemaService.getSchemaBridge((catalog as any).propertiesSchema);
-        render(
-          <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
-            <AutoForm schema={schema!} model={{}} onChangeModel={() => {}}>
-              <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
-            </AutoForm>
-          </AutoField.componentDetectorContext.Provider>,
-        );
-      } catch (e) {
-        /* eslint-disable  @typescript-eslint/no-explicit-any */
-        throw new Error(`Error rendering ${name} component: ${(e as any).message}`);
-      }
+  describe('Exhaustive tests', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
     });
-  });
 
-  it('should render for all kamelets without an error', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const kameletCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.kamelets.file);
-    Object.entries(kameletCatalogMap).forEach(([name, kamelet]) => {
-      try {
-        if (name === 'default') return;
-        expect(kamelet).toBeDefined();
-        /* eslint-disable  @typescript-eslint/no-explicit-any */
-        const schema = (kamelet as any).propertiesSchema;
-        const bridge = schemaService.getSchemaBridge(schema);
-        render(
-          <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
-            <AutoForm schema={bridge!} model={{}} onChangeModel={() => {}}>
-              <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
-            </AutoForm>
-          </AutoField.componentDetectorContext.Provider>,
-        );
-      } catch (e) {
-        /* eslint-disable  @typescript-eslint/no-explicit-any */
-        throw new Error(`Error rendering ${name} component: ${(e as any).message}`);
-      }
+    it('should render for all component without an error', async () => {
+      Object.entries(componentCatalogMap).forEach(([name, catalog]) => {
+        try {
+          if (name === 'default') return;
+          /* eslint-disable  @typescript-eslint/no-explicit-any */
+          const schema = schemaService.getSchemaBridge((catalog as any).propertiesSchema);
+          render(
+            <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+              <AutoForm schema={schema!} model={{}} onChangeModel={() => {}}>
+                <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
+              </AutoForm>
+            </AutoField.componentDetectorContext.Provider>,
+          );
+        } catch (e) {
+          /* eslint-disable  @typescript-eslint/no-explicit-any */
+          throw new Error(`Error rendering ${name} component: ${(e as any).message}`);
+        }
+      });
     });
-  });
 
-  it('should render for all patterns without an error', async () => {
-    const patternCatalogMap = await import('@kaoto-next/camel-catalog/' + catalogIndex.catalogs.patterns.file);
-    Object.entries(patternCatalogMap).forEach(([name, pattern]) => {
-      try {
-        if (name === 'default') return;
-        expect(pattern).toBeDefined();
-        /* eslint-disable  @typescript-eslint/no-explicit-any */
-        const schema = (pattern as any).propertiesSchema;
-        const bridge = schemaService.getSchemaBridge(schema);
-        render(
-          <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
-            <AutoForm schema={bridge!} model={{}} onChangeModel={() => {}}>
-              <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
-            </AutoForm>
-          </AutoField.componentDetectorContext.Provider>,
-        );
-      } catch (e) {
-        /* eslint-disable  @typescript-eslint/no-explicit-any */
-        throw new Error(`Error rendering ${name} pattern: ${(e as any).message}`);
-      }
+    it('should render for all kamelets without an error', async () => {
+      Object.entries(kameletCatalogMap).forEach(([name, kamelet]) => {
+        try {
+          if (name === 'default') return;
+          expect(kamelet).toBeDefined();
+          /* eslint-disable  @typescript-eslint/no-explicit-any */
+          const schema = (kamelet as any).propertiesSchema;
+          const bridge = schemaService.getSchemaBridge(schema);
+          render(
+            <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+              <AutoForm schema={bridge!} model={{}} onChangeModel={() => {}}>
+                <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
+              </AutoForm>
+            </AutoField.componentDetectorContext.Provider>,
+          );
+        } catch (e) {
+          /* eslint-disable  @typescript-eslint/no-explicit-any */
+          throw new Error(`Error rendering ${name} component: ${(e as any).message}`);
+        }
+      });
+    });
+
+    it('should render for all patterns without an error', async () => {
+      Object.entries(patternCatalogMap).forEach(([name, pattern]) => {
+        try {
+          if (name === 'default') return;
+          expect(pattern).toBeDefined();
+          /* eslint-disable  @typescript-eslint/no-explicit-any */
+          const schema = (pattern as any).propertiesSchema;
+          const bridge = schemaService.getSchemaBridge(schema);
+          render(
+            <AutoField.componentDetectorContext.Provider value={CustomAutoFieldDetector}>
+              <AutoForm schema={bridge!} model={{}} onChangeModel={() => {}}>
+                <AutoFields omitFields={SchemaService.OMIT_FORM_FIELDS} />
+              </AutoForm>
+            </AutoField.componentDetectorContext.Provider>,
+          );
+        } catch (e) {
+          /* eslint-disable  @typescript-eslint/no-explicit-any */
+          throw new Error(`Error rendering ${name} pattern: ${(e as any).message}`);
+        }
+      });
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
+++ b/packages/ui/src/components/Visualization/Canvas/__snapshots__/CanvasForm.test.tsx.snap
@@ -23,7 +23,8 @@ exports[`CanvasForm should render 1`] = `
           >
             <img
               alt="icon"
-              class="form-header__icon-1"
+              class="form-header__icon-choice-1234"
+              src=""
             />
             <h2
               class="pf-v5-c-title pf-m-xl form-header__title"
@@ -31,7 +32,7 @@ exports[`CanvasForm should render 1`] = `
               data-ouia-component-type="PF5/Title"
               data-ouia-safe="true"
             >
-              My Node
+              choice
             </h2>
           </div>
           <div
@@ -75,7 +76,7 @@ exports[`CanvasForm should render 1`] = `
         <div>
           <div
             class="pf-v5-c-form__group"
-            data-fieldname="name"
+            data-fieldname="id"
             data-testid="wrapper-field"
           >
             <div
@@ -83,15 +84,43 @@ exports[`CanvasForm should render 1`] = `
             >
               <label
                 class="pf-v5-c-form__label"
-                for="uniforms-0000-0005"
+                for="uniforms-0000-000e"
               >
                 <span
                   class="pf-v5-c-form__label-text"
                 >
-                  Name
+                  Id
                 </span>
               </label>
                
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="More info for field"
+                  class="pf-v5-c-button pf-m-plain field-hint-button"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  data-testid="field-hint-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
             <div
               class="pf-v5-c-form__group-control"
@@ -102,15 +131,16 @@ exports[`CanvasForm should render 1`] = `
                 <input
                   aria-invalid="false"
                   aria-label="uniforms text field"
-                  data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-3"
                   data-ouia-component-type="PF5/TextInput"
                   data-ouia-safe="true"
                   data-testid="text-field"
-                  id="uniforms-0000-0005"
-                  label="Name"
-                  name="name"
+                  description="Sets the id of this node"
+                  id="uniforms-0000-000e"
+                  label="Id"
+                  name="id"
                   type="text"
-                  value="my node"
+                  value=""
                 />
               </span>
               <div
@@ -125,6 +155,248 @@ exports[`CanvasForm should render 1`] = `
                     <span
                       class="pf-v5-c-helper-text__item-text"
                     />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="pf-v5-c-form__group"
+            data-fieldname="description"
+            data-testid="wrapper-field"
+          >
+            <div
+              class="pf-v5-c-form__group-label"
+            >
+              <label
+                class="pf-v5-c-form__label"
+                for="uniforms-0000-000h"
+              >
+                <span
+                  class="pf-v5-c-form__label-text"
+                >
+                  Description
+                </span>
+              </label>
+               
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="More info for field"
+                  class="pf-v5-c-button pf-m-plain field-hint-button"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                  data-ouia-component-type="PF5/Button"
+                  data-ouia-safe="true"
+                  data-testid="field-hint-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v5-c-form__group-control"
+            >
+              <span
+                class="pf-v5-c-form-control"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="uniforms text field"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+                  data-ouia-component-type="PF5/TextInput"
+                  data-ouia-safe="true"
+                  data-testid="text-field"
+                  description="Sets the description of this node"
+                  id="uniforms-0000-000h"
+                  label="Description"
+                  name="description"
+                  type="text"
+                  value=""
+                />
+              </span>
+              <div
+                class="pf-v5-c-form__helper-text"
+              >
+                <div
+                  class="pf-v5-c-helper-text"
+                >
+                  <div
+                    class="pf-v5-c-helper-text__item"
+                  >
+                    <span
+                      class="pf-v5-c-helper-text__item-text"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="pf-v5-c-form__group"
+            data-testid="wrapper-field"
+          >
+            <div
+              class="pf-v5-c-form__group-control"
+            >
+              <div
+                style="display: flex; align-items: center;"
+              >
+                 
+                <div
+                  class="pf-v5-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v5-c-check__input"
+                    data-ouia-component-id="OUIA-Generated-Checkbox-3"
+                    data-ouia-component-type="PF5/Checkbox"
+                    data-ouia-safe="true"
+                    data-testid="bool-field"
+                    id="uniforms-0000-000k"
+                    name="disabled"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v5-c-check__label"
+                    for="uniforms-0000-000k"
+                  >
+                    Disabled
+                  </label>
+                </div>
+                <div
+                  style="display: contents;"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="More info for field"
+                    class="pf-v5-c-button pf-m-plain field-hint-button"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    data-testid="field-hint-button"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  class="pf-v5-c-form__helper-text"
+                >
+                  <div
+                    class="pf-v5-c-helper-text"
+                  >
+                    <div
+                      class="pf-v5-c-helper-text__item"
+                    >
+                      <span
+                        class="pf-v5-c-helper-text__item-text"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="pf-v5-c-form__group"
+            data-testid="wrapper-field"
+          >
+            <div
+              class="pf-v5-c-form__group-control"
+            >
+              <div
+                style="display: flex; align-items: center;"
+              >
+                 
+                <div
+                  class="pf-v5-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v5-c-check__input"
+                    data-ouia-component-id="OUIA-Generated-Checkbox-4"
+                    data-ouia-component-type="PF5/Checkbox"
+                    data-ouia-safe="true"
+                    data-testid="bool-field"
+                    id="uniforms-0000-000n"
+                    name="precondition"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v5-c-check__label"
+                    for="uniforms-0000-000n"
+                  >
+                    Precondition
+                  </label>
+                </div>
+                <div
+                  style="display: contents;"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="More info for field"
+                    class="pf-v5-c-button pf-m-plain field-hint-button"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                    data-ouia-component-type="PF5/Button"
+                    data-ouia-safe="true"
+                    data-testid="field-hint-button"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v5-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  class="pf-v5-c-form__helper-text"
+                >
+                  <div
+                    class="pf-v5-c-helper-text"
+                  >
+                    <div
+                      class="pf-v5-c-helper-text__item"
+                    >
+                      <span
+                        class="pf-v5-c-helper-text__item-text"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
@@ -180,7 +452,7 @@ exports[`CanvasForm should render nothing if no schema and no definition is avai
             <button
               aria-disabled="false"
               class="pf-v5-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+              data-ouia-component-id="OUIA-Generated-Button-plain-11"
               data-ouia-component-type="PF5/Button"
               data-ouia-safe="true"
               data-testid="close-side-bar"
@@ -340,7 +612,7 @@ exports[`CanvasForm should render nothing if no schema is available 1`] = `
             <button
               aria-disabled="false"
               class="pf-v5-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-id="OUIA-Generated-Button-plain-10"
               data-ouia-component-type="PF5/Button"
               data-ouia-safe="true"
               data-testid="close-side-bar"

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.test.tsx
@@ -6,11 +6,16 @@ import { IVisibleFlows, VisualFlowsApi } from '../../../../models/visualization/
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { VisibleFLowsContextResult, VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
 import { FlowsList } from './FlowsList';
+import { camelRouteJson } from '../../../../stubs';
 
 const getContextValue = () => {
+  const visualEntity1 = new CamelRouteVisualEntity({ ...camelRouteJson.route, id: 'entity1' });
+  const visualEntity2 = new CamelRouteVisualEntity({ ...camelRouteJson.route, id: 'entity2' });
+
   return {
     currentSchemaType: SourceSchemaType.Integration,
-    visualEntities: [{ id: 'entity1' } as CamelRouteVisualEntity, { id: 'entity2' } as CamelRouteVisualEntity],
+    visualEntities: [visualEntity1, visualEntity2],
+    updateEntitiesFromCamelResource: jest.fn(),
   } as unknown as EntitiesContextResult;
 };
 const getVisibleFlowsContextValue = () => {
@@ -42,14 +47,14 @@ describe('FlowsList.tsx', () => {
     visibleFlowsValue = getVisibleFlowsContextValue();
   });
 
-  test('should render the existing flows', async () => {
+  it('should render the existing flows', async () => {
     const wrapper = render(<FlowsListWithContexts contextValue={contextValue} visibleFlowsValue={visibleFlowsValue} />);
     const flows = await wrapper.findAllByTestId(/flows-list-row-*/);
 
     expect(flows).toHaveLength(2);
   });
 
-  test('should display an empty state when there is no routes available', async () => {
+  it('should display an empty state when there is no routes available', async () => {
     contextValue = { ...contextValue, visualEntities: [] };
     visibleFlowsValue = { ...visibleFlowsValue, visibleFlows: {} };
     const wrapper = render(<FlowsListWithContexts contextValue={contextValue} visibleFlowsValue={visibleFlowsValue} />);
@@ -59,7 +64,7 @@ describe('FlowsList.tsx', () => {
     expect(emptyState).toBeInTheDocument();
   });
 
-  test('should render the flows ids', async () => {
+  it('should render the flows ids', async () => {
     const wrapper = render(<FlowsListWithContexts contextValue={contextValue} visibleFlowsValue={visibleFlowsValue} />);
     const flow1 = await wrapper.findByText('entity1');
     const flow2 = await wrapper.findByText('entity2');
@@ -68,7 +73,7 @@ describe('FlowsList.tsx', () => {
     expect(flow2).toBeInTheDocument();
   });
 
-  test('should make the selected flow visible by clicking on its ID', async () => {
+  it('should make the selected flow visible by clicking on its ID', async () => {
     let resId = '';
     const visFlowApi = new VisualFlowsApi(jest.fn);
     jest.spyOn(visFlowApi, 'toggleFlowVisible').mockImplementation((id: string) => {
@@ -85,7 +90,7 @@ describe('FlowsList.tsx', () => {
     expect(resId).toBe('entity1');
   });
 
-  test('should call onClose when clicking on a flow ID', async () => {
+  it('should call onClose when clicking on a flow ID', async () => {
     const onCloseSpy = jest.fn();
 
     const wrapper = render(
@@ -101,7 +106,7 @@ describe('FlowsList.tsx', () => {
     expect(onCloseSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('should toggle the visibility of a flow clicking on the Eye icon', async () => {
+  it('should toggle the visibility of a flow clicking on the Eye icon', async () => {
     let resId = '';
     const visFlowApi = new VisualFlowsApi(jest.fn);
     jest.spyOn(visFlowApi, 'toggleFlowVisible').mockImplementation((id: string) => {
@@ -119,7 +124,7 @@ describe('FlowsList.tsx', () => {
     expect(resId).toEqual('entity1');
   });
 
-  test('should render the appropriate Eye icon', async () => {
+  it('should render the appropriate Eye icon', async () => {
     const wrapper = render(<FlowsListWithContexts contextValue={contextValue} visibleFlowsValue={visibleFlowsValue} />);
     const flow1 = await wrapper.findByTestId('toggle-btn-entity1-visible');
     expect(flow1).toBeInTheDocument();
@@ -127,5 +132,33 @@ describe('FlowsList.tsx', () => {
     /** Eye slash icon */
     const flow2 = await wrapper.findByTestId('toggle-btn-entity2-hidden');
     expect(flow2).toBeInTheDocument();
+  });
+
+  it('should rename a flow', async () => {
+    const visualFlowsApi = new VisualFlowsApi(jest.fn);
+    const renameSpy = jest.spyOn(visualFlowsApi, 'renameFlow');
+
+    visibleFlowsValue = { ...getVisibleFlowsContextValue(), visualFlowsApi };
+    const wrapper = render(<FlowsListWithContexts contextValue={contextValue} visibleFlowsValue={visibleFlowsValue} />);
+
+    await act(async () => {
+      const entityOnePencilIcon = await wrapper.findByTestId('goto-btn-entity1--edit');
+      fireEvent.click(entityOnePencilIcon);
+    });
+
+    await act(async () => {
+      const input = await wrapper.findByDisplayValue('entity1');
+      fireEvent.change(input, { target: { value: 'new-name' } });
+      fireEvent.blur(input);
+    });
+
+    await act(async () => {
+      const entityOnePencilIcon = await wrapper.findByTestId('goto-btn-entity1--save');
+      fireEvent.click(entityOnePencilIcon);
+    });
+
+    expect(renameSpy).toHaveBeenCalledWith('entity1', 'new-name');
+    expect(contextValue.visualEntities[0].id).toEqual('new-name');
+    expect(contextValue.updateEntitiesFromCamelResource).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/Flows/FlowsList.tsx
@@ -66,6 +66,7 @@ export const FlowsList: FunctionComponent<IFlowsList> = (props) => {
                   onSelectFlow(flow.id);
                 }}
                 onChange={(name) => {
+                  visualFlowsApi.renameFlow(flow.id, name);
                   flow.setId(name);
                   updateEntitiesFromCamelResource();
                 }}

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -72,7 +72,8 @@ export abstract class AbstractCamelVisualEntity implements BaseVisualCamelEntity
     const updatedValue = CamelComponentSchemaService.getUriSerializedDefinition(path, value);
 
     setValue(this.route, path, updatedValue);
-    this.id = this.route.id;
+
+    if (isDefined(this.route.id)) this.id = this.route.id;
   }
 
   /**

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.test.ts
@@ -1,0 +1,59 @@
+import { VisualFlowsApi } from './flows-visibility';
+
+describe('VisualFlowsApi', () => {
+  let dispatch: jest.Mock;
+  let visualFlowsApi: VisualFlowsApi;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+    visualFlowsApi = new VisualFlowsApi(dispatch);
+  });
+
+  it('should toggle flow visibility', () => {
+    visualFlowsApi.toggleFlowVisible('flowId');
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'toggleFlowVisible', flowId: 'flowId', isVisible: undefined });
+  });
+
+  it('should toggle flow visibility with a given flag', () => {
+    visualFlowsApi.toggleFlowVisible('flowId', true);
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'toggleFlowVisible', flowId: 'flowId', isVisible: true });
+  });
+
+  it('should show all flows', () => {
+    visualFlowsApi.showAllFlows();
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'showAllFlows' });
+  });
+
+  it('should hide all flows', () => {
+    visualFlowsApi.hideAllFlows();
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'hideAllFlows' });
+  });
+
+  it('should set visible flows', () => {
+    visualFlowsApi.setVisibleFlows(['flowId']);
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'setVisibleFlows', flows: ['flowId'] });
+  });
+
+  it('should clear flows', () => {
+    visualFlowsApi.clearFlows();
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'clearFlows' });
+  });
+
+  it('should init visible flows', () => {
+    visualFlowsApi.initVisibleFlows({ flowId: true });
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'initVisibleFlows', visibleFlows: { flowId: true } });
+  });
+
+  it('should rename flow', () => {
+    visualFlowsApi.renameFlow('flowId', 'newName');
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'renameFlow', flowId: 'flowId', newName: 'newName' });
+  });
+});

--- a/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
+++ b/packages/ui/src/models/visualization/flows/support/flows-visibility.ts
@@ -43,7 +43,8 @@ type VisibleFlowAction =
   | { type: 'hideAllFlows' }
   | { type: 'clearFlows' }
   | { type: 'setVisibleFlows'; flows: string[] }
-  | { type: 'initVisibleFlows'; visibleFlows: IVisibleFlows };
+  | { type: 'initVisibleFlows'; visibleFlows: IVisibleFlows }
+  | { type: 'renameFlow'; flowId: string; newName: string };
 
 export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAction) {
   let visibleFlows;
@@ -84,6 +85,16 @@ export function VisibleFlowsReducer(state: IVisibleFlows, action: VisibleFlowAct
       return {};
     case 'initVisibleFlows':
       return { ...action.visibleFlows };
+
+    case 'renameFlow':
+      // eslint-disable-next-line no-case-declarations
+      const newState = {
+        ...state,
+        [action.newName]: state[action.flowId],
+      };
+      delete newState[action.flowId];
+
+      return newState;
   }
 }
 
@@ -116,5 +127,9 @@ export class VisualFlowsApi {
 
   initVisibleFlows(visibleFlows: IVisibleFlows) {
     this.dispatch({ type: 'initVisibleFlows', visibleFlows: visibleFlows });
+  }
+
+  renameFlow(flowId: string, newName: string) {
+    this.dispatch({ type: 'renameFlow', flowId, newName });
   }
 }


### PR DESCRIPTION
### Context

This PR fixes 2 things:
1. When renaming a visible route, the canvas loses track of it and then shows the first route
2. When closing the Canvas Form, the flows list is updated

Currently, the tests for CanvasForm are failing due to the lack of the `VisualizationProvider`